### PR TITLE
Harmoniseer io_output naar output_method en update legacy-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ Datalake Foundation is upgraded to Scala 2.13 for Databricks Runtime 16.4 LTS
 ## 9. Summary
 
 ### IO Output
-Use `io_output` in the `environment` section to configure whether entities return file system paths (`paths`) or catalog table names (`catalog`).
-Individual entities can override this setting in their `settings` block using the same property. The default value is `paths` for backward compatibility.
+
+Use the `output_method` key in the `environment` section to configure whether entities return file paths (`paths`) or catalog tables (`catalog`). Individual entities can override this setting in their `settings` block using the same key. The default value is `paths` for backward compatibility.
+> Note: older configurations may still use the `io_output` key. This is ignored by the current implementation.
 
 ## Scala 2.13 Migration
 Databricks Runtime 16.4 LTS introduces Scala 2.13 support. The project now uses

--- a/src/test/scala/datalake/metadata/IOOutputSpec.scala
+++ b/src/test/scala/datalake/metadata/IOOutputSpec.scala
@@ -7,8 +7,8 @@ import org.json4s.FieldSerializer
 import org.json4s.jackson.Serialization.{read, write}
 class IOOutputSpec extends AnyFunSuite with SparkSessionTest {
   
-  test("Entity with default settings should return Paths") {
-    // Create test metadata with default paths setting
+  test("Legacy io_output configuration should return Paths") {
+    // Create test metadata with legacy io_output paths setting
     val metadataSettings = new StringMetadataSettings()
     val configJson = """
     {
@@ -68,8 +68,8 @@ class IOOutputSpec extends AnyFunSuite with SparkSessionTest {
     paths.silverpath should startWith("/data/silver")
   }
 
-  test("Entity with catalog settings should return CatalogTables") {
-    // Create test metadata with catalog setting
+  test("Entity with catalog output_method should return CatalogTables") {
+    // Create test metadata with catalog output_method setting
     val metadataSettings = new StringMetadataSettings()
     val configJson = """
     {
@@ -98,7 +98,7 @@ class IOOutputSpec extends AnyFunSuite with SparkSessionTest {
     // Create a metadata instance with the test settings
     implicit val metadata = new Metadata(metadataSettings)
 
-    // Create an entity with catalog settings
+    // Create an entity with catalog output_method settings
     val entity = new Entity(
       metadata = metadata,
       id = 2,
@@ -126,7 +126,7 @@ class IOOutputSpec extends AnyFunSuite with SparkSessionTest {
   }
 
   test("Entity can override environment output_method setting") {
-    // Create test metadata with paths as default
+    // Create test metadata with paths as default output_method
     val metadataSettings = new StringMetadataSettings()
     val configJson = """
     {
@@ -171,7 +171,7 @@ class IOOutputSpec extends AnyFunSuite with SparkSessionTest {
     // Create a metadata instance with the test settings
     implicit val metadata = new Metadata(metadataSettings)
 
-    // Create an entity that overrides to use catalog
+    // Create an entity that overrides environment output_method to use catalog
     val entity = metadata.getEntity(3)
 
     // Assert that the entity returns CatalogTables despite environment setting


### PR DESCRIPTION
## Summary
- Documenteer `output_method` als sleutel voor IO Output en negeer legacy `io_output`
- Vertaal de IO Output-sectie in de README naar Engels
- Actualiseer IOOutputSpec met geüpdatete testnamen en commentaar, inclusief een legacy-test

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68a3135e5f10832ea599558393a88a5a