### PR TITLE
Loglevel config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .metals
 project/metals.sbt
 
+# Spark
+spark-warehouse
+
 # vs code
 .vscode
 

--- a/LOG_LEVEL_CONFIG.md
+++ b/LOG_LEVEL_CONFIG.md
@@ -1,0 +1,70 @@
+# Log Level Configuration
+
+The Data Lake Foundation library now supports configurable log levels through the metadata configuration file.
+
+## Configuration
+
+Add the `log_level` field to the `environment` section of your metadata JSON:
+
+```json
+{
+  "environment": {
+    "name": "PRODUCTION",
+    "timezone": "UTC",
+    "root_folder": "/data",
+    "raw_path": "raw",
+    "bronze_path": "bronze", 
+    "silver_path": "silver",
+    "secure_container_suffix": "",
+    "log_level": "INFO"
+  },
+  ...
+}
+```
+
+## Supported Log Levels
+
+The following log levels are supported (in order of verbosity):
+
+- `TRACE` - Most verbose, shows all log messages
+- `DEBUG` - Detailed diagnostic information
+- `INFO` - General information about application execution
+- `WARN` - Warning messages for potentially harmful situations
+- `ERROR` - Error messages for error conditions
+- `FATAL` - Very severe error events that may cause termination
+- `OFF` - No logging output
+
+## Default Behavior
+
+If `log_level` is not specified in the environment configuration, the library defaults to `WARN` level.
+
+## Examples
+
+### Production Environment
+```json
+{
+  "environment": {
+    "log_level": "INFO"
+  }
+}
+```
+
+### Development Environment
+```json
+{
+  "environment": {
+    "log_level": "DEBUG"
+  }
+}
+```
+
+### Quiet Environment
+```json
+{
+  "environment": {
+    "log_level": "WARN"
+  }
+}
+```
+
+This configuration applies to all loggers created through the Data Lake Foundation's `DatalakeLogManager`.

--- a/src/main/scala/datalake/log/DatalakeLogManager.scala
+++ b/src/main/scala/datalake/log/DatalakeLogManager.scala
@@ -2,10 +2,16 @@ package datalake.log
 
 import org.apache.logging.log4j.{LogManager, Logger}
 import org.apache.spark.sql.SparkSession
+import datalake.metadata.Environment
 
 object DatalakeLogManager {
   def getLogger(cls: Class[_])(implicit spark: SparkSession): Logger = {
     Log4jConfigurator.init(spark)
+    LogManager.getLogger(cls)
+  }
+  
+  def getLogger(cls: Class[_], environment: Environment)(implicit spark: SparkSession): Logger = {
+    Log4jConfigurator.init(spark, Some(environment))
     LogManager.getLogger(cls)
   }
 }

--- a/src/main/scala/datalake/log/Log4jConfigurator.scala
+++ b/src/main/scala/datalake/log/Log4jConfigurator.scala
@@ -4,11 +4,12 @@ import org.apache.logging.log4j.{Level, LogManager}
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.config.{Configurator, LoggerConfig}
 import org.apache.spark.sql.SparkSession
+import datalake.metadata.Environment
 
 object Log4jConfigurator {
   @volatile private var initialized = false
 
-  def init(spark: SparkSession): Unit = synchronized {
+  def init(spark: SparkSession, environment: Option[Environment] = None): Unit = synchronized {
     if (!initialized) {
       val ctx = LoggerContext.getContext(false)
       val config = ctx.getConfiguration
@@ -17,16 +18,23 @@ object Log4jConfigurator {
       // parquetAppender.start()
 
       val loggerName = "datalake"
+      
+      // Determine log level from environment or default to WARN
+      val logLevel = environment match {
+        case Some(env) => parseLogLevel(env.LogLevel)
+        case None => Level.WARN
+      }
+      
       val loggerConfig = Option(config.getLoggerConfig(loggerName))
         .filter(_.getName == loggerName)
         .getOrElse {
-          val newConfig = new LoggerConfig(loggerName, Level.DEBUG, true)
+          val newConfig = new LoggerConfig(loggerName, logLevel, true)
           config.addLogger(loggerName, newConfig)
           newConfig
         }
 
-      // Ensure the datalake logger is always set to DEBUG level
-      // loggerConfig.setLevel(Level.DEBUG)
+      // Set the logger level from environment configuration
+      loggerConfig.setLevel(logLevel)
 
       // loggerConfig.addAppender(parquetAppender, Level.INFO, null)
 
@@ -34,6 +42,19 @@ object Log4jConfigurator {
       ctx.updateLoggers()
 
       initialized = true
+    }
+  }
+  
+  private def parseLogLevel(levelString: String): Level = {
+    levelString.toUpperCase match {
+      case "TRACE" => Level.TRACE
+      case "DEBUG" => Level.DEBUG
+      case "INFO" => Level.INFO
+      case "WARN" => Level.WARN
+      case "ERROR" => Level.ERROR
+      case "FATAL" => Level.FATAL
+      case "OFF" => Level.OFF
+      case _ => Level.WARN // Default fallback
     }
   }
 }

--- a/src/main/scala/datalake/metadata/Entity.scala
+++ b/src/main/scala/datalake/metadata/Entity.scala
@@ -16,6 +16,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{ DataFrame, Column, Row, Dataset }
 import org.apache.spark.sql.types._
 import org.apache.logging.log4j.{ LogManager, Logger, Level }
+import datalake.log.DatalakeLogManager
 
 import org.json4s.CustomSerializer
 import org.json4s.jackson.JsonMethods.{ render, parse }
@@ -39,10 +40,13 @@ class Entity(
     val settings: JObject,
     val transformations: Array[EntityTransformation]
 ) extends Serializable {
+  private implicit val spark: SparkSession =
+    SparkSession.builder().getOrCreate()
+  
   implicit val environment: Environment = metadata.getEnvironment
 
   @transient
-  private lazy val logger: Logger = LogManager.getLogger(this.getClass)
+  private lazy val logger: Logger = DatalakeLogManager.getLogger(this.getClass, environment)
 
   private val resolvedOutput: Output = parseOutput()
 

--- a/src/main/scala/datalake/metadata/Entity.scala
+++ b/src/main/scala/datalake/metadata/Entity.scala
@@ -40,7 +40,7 @@ class Entity(
     val settings: JObject,
     val transformations: Array[EntityTransformation]
 ) extends Serializable {
-  private implicit val spark: SparkSession =
+  implicit val spark: SparkSession =
     SparkSession.builder().getOrCreate()
   
   implicit val environment: Environment = metadata.getEnvironment

--- a/src/main/scala/datalake/metadata/Environment.scala
+++ b/src/main/scala/datalake/metadata/Environment.scala
@@ -23,7 +23,8 @@ case class Environment(
   private val systemfield_prefix: String = null,
   private val output_method: String = "paths",
   private val bronze_output: String = null,
-  private val silver_output: String = null
+  private val silver_output: String = null,
+  private val log_level: String = "WARN"
 ) extends Serializable {
 
   override def toString(): String = s"Environment: ${this.name}"
@@ -90,4 +91,6 @@ case class Environment(
 
   def SilverOutput: String =
     if (this.silver_output == null) this.output_method else this.silver_output
+
+  def LogLevel: String = this.log_level
 }

--- a/src/main/scala/datalake/metadata/metadata.scala
+++ b/src/main/scala/datalake/metadata/metadata.scala
@@ -6,6 +6,7 @@ import datalake.processing._
 import java.util.TimeZone
 
 import org.apache.logging.log4j.{Logger, Level, LogManager}
+import datalake.log.DatalakeLogManager
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
@@ -30,8 +31,11 @@ class Metadata(metadataSettings: DatalakeMetadataSettings, env: Environment) ext
     SparkSession.builder().getOrCreate()
   import spark.implicits._
 
+  metadataSettings.setMetadata(this)
+  implicit val environment: Environment = env
+
   @transient 
-  lazy private val logger: Logger = LogManager.getLogger(this.getClass())
+  lazy private val logger: Logger = DatalakeLogManager.getLogger(this.getClass, environment)
 
   if (!metadataSettings.isInitialized()) {
     val e = new MetadataNotInitializedException("Config is not initialized")
@@ -41,10 +45,6 @@ class Metadata(metadataSettings: DatalakeMetadataSettings, env: Environment) ext
   else {
     logger.info("Datalake metadata class Initialized.")
   }
-  
-
-  metadataSettings.setMetadata(this)
-  implicit val environment: Environment = env
 
   def getEntity(id: Int): Entity = {
     val entity = metadataSettings.getEntity(id)

--- a/src/main/scala/datalake/processing/Processing.scala
+++ b/src/main/scala/datalake/processing/Processing.scala
@@ -64,7 +64,7 @@ class Processing(private val entity: Entity, sliceFile: String, options: Map[Str
   import spark.implicits._
 
   @transient 
-  private lazy val logger = DatalakeLogManager.getLogger(this.getClass)
+  private lazy val logger = DatalakeLogManager.getLogger(this.getClass, environment)
 
   def getSource: DatalakeSource = {
     logger.debug(s"getSource called by ${Thread.currentThread().getName}")

--- a/src/test/scala/datalake/log/DefaultLogLevelTest.scala
+++ b/src/test/scala/datalake/log/DefaultLogLevelTest.scala
@@ -1,0 +1,42 @@
+package datalake.log
+
+import org.scalatest.funsuite.AnyFunSuite
+import datalake.metadata._
+
+class DefaultLogLevelTest extends AnyFunSuite with SparkSessionTest {
+  test("Default log level should be WARN when not specified in metadata") {
+    import spark.implicits._
+    
+    // Create metadata configuration without specifying log_level
+    val metadataSettings = new StringMetadataSettings()
+    val configJson = """
+    {
+      "environment": {
+        "name": "test_default",
+        "root_folder": "/data",
+        "timezone": "UTC",
+        "raw_path": "raw",
+        "bronze_path": "bronze",
+        "silver_path": "silver", 
+        "secure_container_suffix": "",
+        "output_method": "paths"
+      },
+      "connections": [
+        {
+          "name": "test_connection",
+          "enabled": true,
+          "settings": {}
+        }
+      ],
+      "entities": []
+    }
+    """
+    metadataSettings.initialize(configJson)
+    
+    // Create metadata instance - should default to WARN level
+    implicit val metadata = new Metadata(metadataSettings)
+    
+    // Verify the default log level is WARN
+    assert(metadata.getEnvironment.LogLevel == "WARN", "Default log level should be WARN")
+  }
+}

--- a/src/test/scala/datalake/log/LogLevelConfigTest.scala
+++ b/src/test/scala/datalake/log/LogLevelConfigTest.scala
@@ -1,0 +1,69 @@
+package datalake.log
+
+import org.scalatest.funsuite.AnyFunSuite
+import datalake.metadata._
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.LoggerContext
+
+class LogLevelConfigTest extends AnyFunSuite with SparkSessionTest {
+  test("Log level should be configurable from environment") {
+    import spark.implicits._
+    
+    // Test with INFO level
+    val infoEnv = new Environment(
+      "TEST",
+      "/tmp/test",
+      "UTC",
+      "raw",
+      "bronze", 
+      "silver",
+      "",
+      output_method = "paths",
+      log_level = "INFO"
+    )
+    
+    // Reset Log4jConfigurator before test
+    val initializedField = Log4jConfigurator.getClass.getDeclaredField("initialized")
+    initializedField.setAccessible(true)
+    initializedField.set(Log4jConfigurator, false)
+    
+    // Initialize log4j with INFO level
+    Log4jConfigurator.init(spark, Some(infoEnv))
+    
+    val ctx = LoggerContext.getContext(false)
+    val config = ctx.getConfiguration
+    val loggerConfig = config.getLoggerConfig("datalake")
+    
+    assert(loggerConfig.getLevel == Level.INFO, "Log level should be set to INFO")
+  }
+  
+  test("Log level should default to WARN when not specified") {
+    import spark.implicits._
+    
+    val defaultEnv = new Environment(
+      "TEST",
+      "/tmp/test",
+      "UTC", 
+      "raw",
+      "bronze",
+      "silver",
+      "",
+      output_method = "paths"
+      // log_level not specified, should default to WARN
+    )
+    
+    // Reset Log4jConfigurator for new test  
+    val initializedField2 = Log4jConfigurator.getClass.getDeclaredField("initialized")
+    initializedField2.setAccessible(true)
+    initializedField2.set(Log4jConfigurator, false)
+    
+    // Initialize log4j with default level
+    Log4jConfigurator.init(spark, Some(defaultEnv))
+    
+    val ctx = LoggerContext.getContext(false)
+    val config = ctx.getConfiguration
+    val loggerConfig = config.getLoggerConfig("datalake")
+    
+    assert(loggerConfig.getLevel == Level.WARN, "Log level should default to WARN")
+  }
+}

--- a/src/test/scala/datalake/log/LogLevelConfigTest.scala
+++ b/src/test/scala/datalake/log/LogLevelConfigTest.scala
@@ -25,7 +25,7 @@ class LogLevelConfigTest extends AnyFunSuite with SparkSessionTest {
     // Reset Log4jConfigurator before test
     val initializedField = Log4jConfigurator.getClass.getDeclaredField("initialized")
     initializedField.setAccessible(true)
-    initializedField.set(Log4jConfigurator, false)
+    Log4jConfigurator.reset()
     
     // Initialize log4j with INFO level
     Log4jConfigurator.init(spark, Some(infoEnv))

--- a/src/test/scala/datalake/log/LogLevelConfigTest.scala
+++ b/src/test/scala/datalake/log/LogLevelConfigTest.scala
@@ -25,7 +25,7 @@ class LogLevelConfigTest extends AnyFunSuite with SparkSessionTest {
     // Reset Log4jConfigurator before test
     val initializedField = Log4jConfigurator.getClass.getDeclaredField("initialized")
     initializedField.setAccessible(true)
-    Log4jConfigurator.reset()
+    initializedField.set(Log4jConfigurator, false)
     
     // Initialize log4j with INFO level
     Log4jConfigurator.init(spark, Some(infoEnv))

--- a/src/test/scala/datalake/processing/BenchmarkSpec.scala
+++ b/src/test/scala/datalake/processing/BenchmarkSpec.scala
@@ -1,9 +1,7 @@
-package datalake.metadata
+package datalake.processing
 
 import org.scalatest.funsuite.AnyFunSuite
-
 import datalake.metadata._
-import datalake.processing._
 
 class BenchmarkSpec extends AnyFunSuite with SparkSessionTest {
   test("Benchmark Full, Merge and Historic processing") {
@@ -30,7 +28,8 @@ class BenchmarkSpec extends AnyFunSuite with SparkSessionTest {
       "/${connection}/${entity}",
       "/${connection}/${destination}",
       "-secure", 
-      output_method = "paths"
+      output_method = "paths",
+      log_level = "WARN"
     )
 
     val settings = new JsonMetadataSettings()

--- a/src/test/scala/example/LogLevelExample.scala
+++ b/src/test/scala/example/LogLevelExample.scala
@@ -1,0 +1,163 @@
+package example
+
+import datalake.metadata._
+import datalake.log.DatalakeLogManager
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Example demonstrating how to use configurable log levels in the Data Lake Foundation library.
+ * 
+ * This example shows how to:
+ * 1. Configure log levels through metadata JSON
+ * 2. Create environments with different log levels
+ * 3. Use the DatalakeLogManager with environment-specific logging
+ */
+object LogLevelExample {
+  
+  def main(args: Array[String]): Unit = {
+    implicit val spark: SparkSession = SparkSession.builder()
+      .appName("Log Level Example")
+      .master("local[*]")
+      .getOrCreate()
+    
+    try {
+      exampleWithInfoLevel()
+      exampleWithWarnLevel()
+      exampleWithDefaultLevel()
+    } finally {
+      spark.stop()
+    }
+  }
+  
+  /**
+   * Example: Configure log level through metadata JSON
+   */
+  def exampleWithInfoLevel()(implicit spark: SparkSession): Unit = {
+    println("=== Example 1: INFO Log Level via Metadata ===")
+    
+    // Create metadata configuration with INFO log level
+    val metadataSettings = new StringMetadataSettings()
+    val configJson = """
+    {
+      "environment": {
+        "name": "example",
+        "root_folder": "/data",
+        "timezone": "UTC",
+        "raw_path": "raw",
+        "bronze_path": "bronze",
+        "silver_path": "silver", 
+        "secure_container_suffix": "",
+        "output_method": "paths",
+        "log_level": "INFO"
+      },
+      "connections": [
+        {
+          "name": "example_connection",
+          "enabled": true,
+          "settings": {}
+        }
+      ],
+      "entities": []
+    }
+    """
+    metadataSettings.initialize(configJson)
+    
+    // Create metadata instance - this will initialize logging with INFO level
+    implicit val metadata = new Metadata(metadataSettings)
+    
+    // Get logger - will be configured with INFO level from environment
+    val logger = DatalakeLogManager.getLogger(this.getClass, metadata.getEnvironment)
+    
+    println(s"Configured log level: ${metadata.getEnvironment.LogLevel}")
+    
+    // These log messages will be shown based on the configured level
+    logger.info("This INFO message will be shown (log level is INFO)")
+    logger.warn("This WARN message will be shown (log level is INFO)")
+    logger.error("This ERROR message will be shown (log level is INFO)")
+    
+    // This DEBUG message will NOT be shown because log level is INFO
+    logger.debug("This DEBUG message will NOT be shown (log level is INFO)")
+    
+    println()
+  }
+  
+  /**
+   * Example: Create environment with WARN log level directly
+   */
+  def exampleWithWarnLevel()(implicit spark: SparkSession): Unit = {
+    println("=== Example 2: WARN Log Level via Environment ===")
+    
+    // Create environment with WARN log level directly
+    val environment = new Environment(
+      name = "example_warn",
+      root_folder = "/data",
+      timezone = "UTC", 
+      raw_path = "raw",
+      bronze_path = "bronze",
+      silver_path = "silver",
+      secure_container_suffix = "",
+      output_method = "paths",
+      log_level = "WARN"
+    )
+    
+    // Get logger configured with WARN level
+    val logger = DatalakeLogManager.getLogger(this.getClass, environment)
+    
+    println(s"Configured log level: ${environment.LogLevel}")
+    
+    // Only WARN and higher level messages will be shown
+    logger.warn("This WARN message will be shown")
+    logger.error("This ERROR message will be shown")
+    
+    // These will NOT be shown because log level is WARN
+    logger.info("This INFO message will NOT be shown")
+    logger.debug("This DEBUG message will NOT be shown")
+    
+    println()
+  }
+  
+  /**
+   * Example: Default log level behavior
+   */
+  def exampleWithDefaultLevel()(implicit spark: SparkSession): Unit = {
+    println("=== Example 3: Default Log Level (WARN) ===")
+    
+    // Create metadata configuration without specifying log_level
+    val metadataSettings = new StringMetadataSettings()
+    val configJson = """
+    {
+      "environment": {
+        "name": "default_example",
+        "root_folder": "/data",
+        "timezone": "UTC",
+        "raw_path": "raw",
+        "bronze_path": "bronze",
+        "silver_path": "silver", 
+        "secure_container_suffix": "",
+        "output_method": "paths"
+      },
+      "connections": [],
+      "entities": []
+    }
+    """
+    metadataSettings.initialize(configJson)
+    
+    // Create metadata instance - should default to WARN level
+    implicit val metadata = new Metadata(metadataSettings)
+    
+    // Get logger with default configuration
+    val logger = DatalakeLogManager.getLogger(this.getClass, metadata.getEnvironment)
+    
+    println(s"Default log level: ${metadata.getEnvironment.LogLevel}")
+    
+    // Only WARN and higher level messages will be shown (default behavior)
+    logger.warn("This WARN message will be shown (default level)")
+    logger.error("This ERROR message will be shown (default level)")
+    
+    // These will NOT be shown because default level is WARN
+    logger.info("This INFO message will NOT be shown (default level)")
+    logger.debug("This DEBUG message will NOT be shown (default level)")
+    
+    println()
+  }
+}

--- a/src/test/scala/example/metadata.json
+++ b/src/test/scala/example/metadata.json
@@ -8,7 +8,8 @@
 		"silver_path": "/${connection}/${destination}",
 		"secure_container_suffix": "-secure",
 		"systemfield_prefix": "dlf_",
-		"output": "paths"
+		"output": "paths",
+		"log_level": "INFO"
 	},
 	"connections": [
 		{


### PR DESCRIPTION
This pull request adds support for configurable log levels in the Data Lake Foundation library, allowing users to set the desired logging verbosity through the metadata configuration. The implementation introduces a new `log_level` field in the environment settings, updates how loggers are initialized to respect this configuration, and includes documentation and tests to validate the feature.