### PR TITLE
Refactor Environment fields to use Option

### DIFF
--- a/src/main/scala/datalake/metadata/Environment.scala
+++ b/src/main/scala/datalake/metadata/Environment.scala
@@ -19,11 +19,11 @@ case class Environment(
   private val raw_path: String,
   private val bronze_path: String,
   private val silver_path: String,
-  private val secure_container_suffix: String,
-  private val systemfield_prefix: String = null,
+  private val secure_container_suffix: Option[String] = None,
+  private val systemfield_prefix: Option[String] = None,
   private val output_method: String = "paths",
-  private val bronze_output: String = null,
-  private val silver_output: String = null,
+  private val bronze_output: Option[String] = None,
+  private val silver_output: Option[String] = None,
   private val log_level: String = "WARN"
 ) extends Serializable {
 
@@ -76,21 +76,19 @@ case class Environment(
     silverPath
   }
 
-  def SystemFieldPrefix: String = {
-    if (this.systemfield_prefix == null) "" else this.systemfield_prefix
-  }
+  def SystemFieldPrefix: String =
+    this.systemfield_prefix.getOrElse("")
 
-  def SecureContainerSuffix: String = {
-      if (this.secure_container_suffix == null) "" else this.secure_container_suffix
-  }
+  def SecureContainerSuffix: String =
+    this.secure_container_suffix.getOrElse("")
 
   def OutputMethod: String = this.output_method
 
   def BronzeOutput: String =
-    if (this.bronze_output == null) this.output_method else this.bronze_output
+    this.bronze_output.getOrElse(this.output_method)
 
   def SilverOutput: String =
-    if (this.silver_output == null) this.output_method else this.silver_output
+    this.silver_output.getOrElse(this.output_method)
 
   def LogLevel: String = this.log_level
 }

--- a/src/test/scala/datalake/log/LogLevelConfigTest.scala
+++ b/src/test/scala/datalake/log/LogLevelConfigTest.scala
@@ -15,9 +15,8 @@ class LogLevelConfigTest extends AnyFunSuite with SparkSessionTest {
       "/tmp/test",
       "UTC",
       "raw",
-      "bronze", 
+      "bronze",
       "silver",
-      "",
       output_method = "paths",
       log_level = "INFO"
     )
@@ -47,7 +46,6 @@ class LogLevelConfigTest extends AnyFunSuite with SparkSessionTest {
       "raw",
       "bronze",
       "silver",
-      "",
       output_method = "paths"
       // log_level not specified, should default to WARN
     )

--- a/src/test/scala/datalake/processing/BenchmarkSpec.scala
+++ b/src/test/scala/datalake/processing/BenchmarkSpec.scala
@@ -27,7 +27,7 @@ class BenchmarkSpec extends AnyFunSuite with SparkSessionTest {
       "/${connection}/${entity}",
       "/${connection}/${entity}",
       "/${connection}/${destination}",
-      "-secure", 
+      secure_container_suffix = Some("-secure"),
       output_method = "paths",
       log_level = "WARN"
     )

--- a/src/test/scala/example/LogLevelExample.scala
+++ b/src/test/scala/example/LogLevelExample.scala
@@ -95,7 +95,7 @@ object LogLevelExample {
       raw_path = "raw",
       bronze_path = "bronze",
       silver_path = "silver",
-      secure_container_suffix = "",
+      secure_container_suffix = Some(""),
       output_method = "paths",
       log_level = "WARN"
     )

--- a/src/test/scala/example/datalake.scala
+++ b/src/test/scala/example/datalake.scala
@@ -42,8 +42,8 @@ trait SparkSessionTest extends Suite with BeforeAndAfterAll with BeforeAndAfterE
     "/${connection}/${entity}",
     "/${connection}/${entity}",
     "/${connection}/${destination}",
-    "-secure",
-    systemfield_prefix = randomPrefix,
+    secure_container_suffix = Some("-secure"),
+    systemfield_prefix = Some(randomPrefix),
     output_method = "paths"
   )
 
@@ -380,8 +380,8 @@ class ProcessingTests extends AnyFunSuite with SparkSessionTest {
       "/${connection}/${entity}",
       "/${connection}/${entity}",
       "/${connection}/${destination}",
-      "-secure",
-      systemfield_prefix = randomPrefix,
+      secure_container_suffix = Some("-secure"),
+      systemfield_prefix = Some(randomPrefix),
       output_method = "paths"
     )
 


### PR DESCRIPTION
## Summary
- Represent nullable Environment parameters as `Option[String]`
- Simplify Environment accessors using `getOrElse`
- Update tests to use new `Option` parameters

## Testing
- `sbt test`