### PR TITLE
refactor: simplify DatalakeColumn

### DIFF
--- a/src/main/scala/datalake/core/DatalakeColumn.scala
+++ b/src/main/scala/datalake/core/DatalakeColumn.scala
@@ -1,40 +1,22 @@
 package datalake.core
 
-import datalake.metadata._
-import org.apache.spark.sql.{ DataFrame, SparkSession, Row }
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.functions.col
-import io.delta.tables._
-import java.sql.Timestamp
-import com.fasterxml.jackson.module.scala.deser.overrides
+import org.apache.spark.sql.types.DataType
 
-class DatalakeColumn(
-    val name: String,
-    val dataType: DataType,
-    val nullable: Boolean,
-    val partOfPartition: Boolean
-) extends Serializable {
+case class DatalakeColumn(
+    name: String,
+    dataType: DataType,
+    nullable: Boolean,
+    partOfPartition: Boolean = false
+) {
 
-  override def toString(): String = this.name
+    override def toString: String = this.name
 
-  override def equals(obj: Any): Boolean = {
-    obj match {
-      case col: DatalakeColumn =>
-        this.name == col.name
-      case _ => false
+    override def equals(obj: Any): Boolean = {
+        obj match {
+            case col: DatalakeColumn => this.name == col.name
+            case _ => false
+        }
     }
-  }
-}
 
-object DatalakeColumn {
-
-  def apply(
-      name: String,
-      data_type: DataType,
-      nullable: Boolean,
-      part_of_partition: Boolean
-  ): DatalakeColumn =
-    new DatalakeColumn(name, data_type, nullable, part_of_partition)
-
-  def apply(name: String, data_type: DataType,nullable: Boolean): DatalakeColumn = new DatalakeColumn(name, data_type, nullable, false)
+    override def hashCode(): Int = name.hashCode
 }


### PR DESCRIPTION
## Summary
- replace DatalakeColumn class/object with concise case class
- drop unused Jackson overrides import
- override equals, hashCode, and toString so columns compare and print by name

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68ad76cb2840832eb5f008fc9bb16796