### PR TITLE
Refactor implicit helpers to camelCase

### DIFF
--- a/src/main/scala/datalake/core/implicits.scala
+++ b/src/main/scala/datalake/core/implicits.scala
@@ -11,9 +11,11 @@ import java.time.LocalDateTime
 
 object implicits {
 
+  // Extension helpers for DataFrame normalization, schema comparison, and path utilities
+
   implicit class DatalakeDataFrame(df: DataFrame) {
 
-    def datalake_normalize(): DataFrame = {
+    def datalakeNormalize(): DataFrame = {
       val columns = df.columns
 
       // drop sys columns
@@ -25,10 +27,10 @@ object implicits {
         tempdf.withColumnRenamed(name._2, name._1)
       }
 
-      return resultingDf
+      resultingDf
     }
 
-    def datalake_schemacompare(targetSchema: StructType): Array[(DatalakeColumn, String)] = {
+    def datalakeSchemaCompare(targetSchema: StructType): Array[(DatalakeColumn, String)] = {
 
       val targetColumns = targetSchema.fields.map(fld => DatalakeColumn(fld.name.toLowerCase(), fld.dataType, fld.nullable ) )
       val sourceColumns = df.schema.fields.map(fld => DatalakeColumn(fld.name.toLowerCase(), fld.dataType, fld.nullable ) )
@@ -65,16 +67,15 @@ object implicits {
         }
       }
 
-      return schemaDifferences.toArray
+      schemaDifferences.toArray
     }
 
   }
 
   implicit class StringFunctions(str: String) {
 
-    def normalized_path: String ={
-      return s"${if (str.toString.startsWith("/")) str else "/" + str}"
-    }
+    def normalizedPath: String =
+      s"${if (str.toString.startsWith("/")) str else "/" + str}"
 
   }
 

--- a/src/main/scala/datalake/metadata/Entity.scala
+++ b/src/main/scala/datalake/metadata/Entity.scala
@@ -199,23 +199,23 @@ class Entity(
 
     // environment override for raw
     _settings.get("raw_path") match {
-      case Some(value: String) => rawPath ++= value.normalized_path
+      case Some(value: String) => rawPath ++= value.normalizedPath
       case _ =>
-        rawPath ++= environment.RawPath.normalized_path
+        rawPath ++= environment.RawPath.normalizedPath
     }
 
     // environment override for bronze
     _settings.get("bronze_path") match {
-      case Some(value: String) => bronzePath ++= value.normalized_path
+      case Some(value: String) => bronzePath ++= value.normalizedPath
       case _ =>
-        bronzePath ++= environment.BronzePath.normalized_path
+        bronzePath ++= environment.BronzePath.normalizedPath
     }
 
     // environment override for silver
     _settings.get("silver_path") match {
-      case Some(value: String) => silverPath ++= value.normalized_path
+      case Some(value: String) => silverPath ++= value.normalizedPath
       case _ =>
-        silverPath ++= environment.SilverPath.normalized_path
+        silverPath ++= environment.SilverPath.normalizedPath
     }
 
     val retRawPath = parseString(rawPath.toString)

--- a/src/main/scala/datalake/processing/Historic.scala
+++ b/src/main/scala/datalake/processing/Historic.scala
@@ -58,7 +58,7 @@ final object Historic extends ProcessStrategy {
       val explicit_partFilter = partition_filters.mkString(" AND ")
       
       // Check for schema changes
-      val schemaChanges = source.datalake_schemacompare(deltaTable.toDF.schema)
+      val schemaChanges = source.datalakeSchemaCompare(deltaTable.toDF.schema)
       if (schemaChanges.nonEmpty) {
         logger.warn(s"Schema changes detected during Historic processing:")
         schemaChanges.foreach(change => logger.warn(s"  ${change.toString}"))

--- a/src/main/scala/datalake/processing/Merge.scala
+++ b/src/main/scala/datalake/processing/Merge.scala
@@ -63,7 +63,7 @@ final object Merge extends ProcessStrategy {
       }
       val explicit_partFilter = partition_values.mkString(" AND ")
 
-      val schemaChanges = source.datalake_schemacompare(deltaTable.toDF.schema)
+      val schemaChanges = source.datalakeSchemaCompare(deltaTable.toDF.schema)
       if (schemaChanges.nonEmpty) {
         logger.warn(s"Schema changes detected during Merge processing:")
         schemaChanges.foreach(change => logger.warn(s"  ${change.toString}"))

--- a/src/main/scala/datalake/processing/Processing.scala
+++ b/src/main/scala/datalake/processing/Processing.scala
@@ -87,7 +87,7 @@ class Processing(private val entity: Entity, sliceFile: String, options: Map[Str
       .transform(addDeletedColumn)
       .transform(addLastSeen)
       .transform(addFilenameColumn(_, sliceFile))
-      .datalake_normalize()
+      .datalakeNormalize()
       .cache() // Cache the DataFrame since it will be used multiple times
 
     // Now trigger actions after all transformations are done


### PR DESCRIPTION
## Summary
- rename `datalake_normalize` to `datalakeNormalize`
- rename `datalake_schemacompare` to `datalakeSchemaCompare`
- rename `normalized_path` to `normalizedPath`
- remove explicit `return` statements

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68ad771a1920832eb9fea62dfea9cc5f